### PR TITLE
Add AWS deployment scripts

### DIFF
--- a/README 2 - AWS Deployment.md
+++ b/README 2 - AWS Deployment.md
@@ -45,7 +45,7 @@ Power BI / QuickSight / Athena
 ### Step 1: Package the Lambda Function
 
 ```bash
-cd godata2023/AWS\ Deployment
+cd godata2023/aws_deployment
 bash deploy/build_lambda_package.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ spark_etl_JZ/
 │ └── trade_*.csv
 ├── README.md
 └── godata2023/ # Phase 2: AWS deployment artifacts
-├── AWS Deployment/
+├── aws_deployment/
 │ ├── fetch_stock_data.py # Lambda handler (configurable ingestion interval)
 │ ├── glue_etl_job.py # Glue PySpark transformation job
 │ ├── deploy/

--- a/godata2023/aws_deployment/deploy/build_lambda_package.sh
+++ b/godata2023/aws_deployment/deploy/build_lambda_package.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+DIR=$(dirname "$0")
+TEMP_DIR=$(mktemp -d)
+cp "$DIR"/../fetch_stock_data.py "$TEMP_DIR"/
+cd "$TEMP_DIR"
+pip install requests boto3 -t . >/dev/null
+zip -r9 "$DIR/../lambda_function.zip" . >/dev/null
+rm -rf "$TEMP_DIR"

--- a/godata2023/aws_deployment/deploy/create_eventbridge_rule.sh
+++ b/godata2023/aws_deployment/deploy/create_eventbridge_rule.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+DIR=$(dirname "$0")
+FUNCTION_NAME=${FUNCTION_NAME:-StockDataFetcher}
+RULE_NAME=${RULE_NAME:-stock-data-schedule}
+# Schedule every 5 minutes by default
+SCHEDULE_EXPRESSION=${SCHEDULE_EXPRESSION:-"rate(5 minutes)"}
+
+aws events put-rule --name $RULE_NAME --schedule-expression "$SCHEDULE_EXPRESSION" >/dev/null
+aws lambda add-permission --function-name $FUNCTION_NAME --statement-id ${RULE_NAME}-perm --action 'lambda:InvokeFunction' --principal events.amazonaws.com --source-arn $(aws events describe-rule --name $RULE_NAME --query 'Arn' --output text) >/dev/null || true
+aws events put-targets --rule $RULE_NAME --targets "Id"="1","Arn"="$(aws lambda get-function --function-name $FUNCTION_NAME --query 'Configuration.FunctionArn' --output text)" >/dev/null

--- a/godata2023/aws_deployment/deploy/deploy_lambda.sh
+++ b/godata2023/aws_deployment/deploy/deploy_lambda.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+DIR=$(dirname "$0")
+FUNCTION_NAME=${FUNCTION_NAME:-StockDataFetcher}
+ROLE_NAME=${ROLE_NAME:-stock-data-lambda-role}
+ZIP_FILE="$DIR/../lambda_function.zip"
+POLICY_FILE="$DIR/lambda_iam_policy.json"
+
+aws iam create-role --role-name $ROLE_NAME --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}' >/dev/null || true
+aws iam put-role-policy --role-name $ROLE_NAME --policy-name lambda-policy --policy-document file://$POLICY_FILE >/dev/null
+aws lambda create-function --function-name $FUNCTION_NAME \
+  --runtime python3.9 --role $(aws iam get-role --role-name $ROLE_NAME --query 'Role.Arn' --output text) \
+  --handler fetch_stock_data.lambda_handler --zip-file fileb://$ZIP_FILE >/dev/null || \
+aws lambda update-function-code --function-name $FUNCTION_NAME --zip-file fileb://$ZIP_FILE >/dev/null

--- a/godata2023/aws_deployment/deploy/lambda_iam_policy.json
+++ b/godata2023/aws_deployment/deploy/lambda_iam_policy.json
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/godata2023/aws_deployment/fetch_stock_data.py
+++ b/godata2023/aws_deployment/fetch_stock_data.py
@@ -1,0 +1,53 @@
+import os
+import json
+import boto3
+import requests
+
+
+def _get_api_key() -> str:
+    """Read API key from environment variable or config file."""
+    api_key = os.getenv("ALPHAVANTAGE_API_KEY")
+    if api_key:
+        return api_key
+    config_path = os.path.join(
+        os.path.dirname(__file__), '..', 'config', 'config.ini'
+    )
+    if os.path.exists(config_path):
+        import configparser
+
+        config = configparser.ConfigParser()
+        config.read(config_path)
+        return config.get('API', 'api_key')
+    raise ValueError('API key not provided')
+
+
+def fetch_stock_data(symbol: str, interval: str = '1min') -> dict:
+    """Fetch stock data from Alpha Vantage."""
+    api_key = _get_api_key()
+    base_url = 'https://www.alphavantage.co/query'
+    params = {
+        'function': 'TIME_SERIES_INTRADAY',
+        'symbol': symbol,
+        'interval': interval,
+        'outputsize': 'compact',
+        'apikey': api_key,
+    }
+    response = requests.get(base_url, params=params, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def upload_to_s3(data: dict, bucket: str, prefix: str, symbol: str) -> None:
+    s3 = boto3.client('s3')
+    key = f"{prefix}/{symbol}/{int(__import__('time').time())}.json"
+    s3.put_object(Bucket=bucket, Key=key, Body=json.dumps(data))
+
+
+def lambda_handler(event, context):
+    symbol_list = os.getenv('SYMBOL_LIST', 'NVDA').split(',')
+    bucket = os.getenv('RAW_BUCKET', 'stock-raw-data')
+    prefix = os.getenv('PREFIX', 'events')
+    for symbol in symbol_list:
+        data = fetch_stock_data(symbol.strip())
+        upload_to_s3(data, bucket, prefix, symbol.strip())
+    return {'status': 'ok', 'symbols': symbol_list}

--- a/godata2023/aws_deployment/glue_etl_job.py
+++ b/godata2023/aws_deployment/glue_etl_job.py
@@ -1,0 +1,22 @@
+import sys
+from awsglue.context import GlueContext
+from awsglue.utils import getResolvedOptions
+from pyspark.context import SparkContext
+from pyspark.sql.functions import col
+
+args = getResolvedOptions(sys.argv, ['RAW_BUCKET', 'CLEAN_BUCKET', 'PREFIX'])
+
+sc = SparkContext()
+ctx = GlueContext(sc)
+
+raw_path = f"s3://{args['RAW_BUCKET']}/{args['PREFIX']}"
+clean_path = f"s3://{args['CLEAN_BUCKET']}/cleaned"
+
+# Read raw JSON files
+df = ctx.spark_session.read.json(raw_path)
+
+# Basic cleaning
+clean_df = df.dropna().dropDuplicates()
+
+# Write to Parquet
+clean_df.write.mode('append').parquet(clean_path)


### PR DESCRIPTION
## Summary
- add sample AWS Lambda function and Glue job
- add helper bash scripts for building and deploying Lambda
- document new `aws_deployment` path in README and AWS deployment guide

## Testing
- `black -S --line-length 79 godata2023/aws_deployment/fetch_stock_data.py godata2023/aws_deployment/glue_etl_job.py`
- `flake8 godata2023/aws_deployment`
- `mypy --ignore-missing-imports --disable-error-code import-untyped godata2023/aws_deployment`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68421829650c832bb28fb511d58c2a38